### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/pancht/nrobo/security/code-scanning/1](https://github.com/pancht/nrobo/security/code-scanning/1)

To fix this problem, specify a `permissions` block at the appropriate level in the workflow YAML. The minimal, safe default is `contents: read`, as recommended by the warning and GitHub documentation. This restricts the automatically generated GITHUB_TOKEN to only have "read" access to repository contents, reducing the potential attack surface. There is no evidence in the workflow steps that any step requires write access (code uploads to Codecov use their own tokens, not GITHUB_TOKEN), so `contents: read` is sufficient. The `permissions` block can be added at the top level, to apply to all jobs in the workflow. No additional methods, imports, or definitions are needed—just add the `permissions:` spec to `.github/workflows/ci.yml` immediately after the `name` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
